### PR TITLE
Add "span" argument to from_newick

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,16 +8,16 @@ repos:
       - id: check-case-conflict
       - id: check-yaml
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: v2.5.0
+    rev: v3.0.1
     hooks:
       - id: reorder-python-imports
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.19.3
+    rev: v2.31.1
     hooks:
       - id: pyupgrade
         args: [--py3-plus, --py37-plus]
   - repo: https://github.com/psf/black
-    rev: 21.5b2
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3

--- a/tests/test_newick.py
+++ b/tests/test_newick.py
@@ -463,7 +463,7 @@ class TestNewicks:
         ):
             tsconvert.from_newick("(2:0.10,3:0.00);")
 
-        ts = tsconvert.from_newick("(2:0.10,3:0.00);", 0.01)
+        ts = tsconvert.from_newick("(2:0.10,3:0.00);", min_edge_length=0.01)
         assert ts.first().newick(precision=2) == "(2:0.10,3:0.01);"
 
     def test_negative_branch_length(self):
@@ -473,7 +473,7 @@ class TestNewicks:
         ):
             tsconvert.from_newick("(2:0.10,3:0.00);")
 
-        ts = tsconvert.from_newick("(2:0.10,3:-10.01);", 0.01)
+        ts = tsconvert.from_newick("(2:0.10,3:-10.01);", min_edge_length=0.01)
         assert ts.first().newick(precision=2) == "(2:0.10,3:0.01);"
 
     def test_ids(self):

--- a/tests/test_newick.py
+++ b/tests/test_newick.py
@@ -498,6 +498,12 @@ class TestNewicks:
             {"comment": '!"£$%^&*_+-={}<>,.?/~#|`¬'},
         )
 
+    def test_span(self):
+        ts = tsconvert.from_newick("(2:0.10,3:0.20);")
+        assert ts.sequence_length == 1.0
+        ts = tsconvert.from_newick("(2:0.10,3:0.20);", span=128.0)
+        assert ts.sequence_length == 128.0
+
     def test_nextstrain_newick(self):
         with open(pathlib.Path(__file__).parent / "data" / "nextstrain.nwk") as f:
             newick = f.read()

--- a/tsconvert/newick.py
+++ b/tsconvert/newick.py
@@ -124,7 +124,7 @@ def to_ms(ts):
     return output
 
 
-def from_newick(string, min_edge_length=0, *, span=1) -> tskit.TreeSequence:
+def from_newick(string, *, min_edge_length=0, span=1) -> tskit.TreeSequence:
     """
     Create a tree sequence representation of the specified newick string.
 

--- a/tsconvert/newick.py
+++ b/tsconvert/newick.py
@@ -124,9 +124,9 @@ def to_ms(ts):
     return output
 
 
-def from_newick(string, min_edge_length=0):
+def from_newick(string, min_edge_length=0, *, span=1) -> tskit.TreeSequence:
     """
-    Returns a tree sequence representation of the specified newick string.
+    Create a tree sequence representation of the specified newick string.
 
     The tree sequence will contain a single tree, as specified by the newick. All
     leaf nodes will be marked as samples (``tskit.NODE_IS_SAMPLE``). Newick names and
@@ -137,6 +137,9 @@ def from_newick(string, min_edge_length=0):
         value. Unlike newick, tskit doesn't support zero or negative edge lengths, so
         setting this argument to a small value is necessary when importing trees with
         zero or negative lengths.
+    :param float span: The span of the tree, and therefore the
+        :attr:`~TreeSequence.sequence_length` of the returned tree sequence.
+    :return: A tree sequence consisting of a single tree.
     """
     trees = newick.loads(string)
     if len(trees) > 1:
@@ -144,7 +147,7 @@ def from_newick(string, min_edge_length=0):
     if len(trees) == 0:
         raise ValueError("Newick string was empty")
     tree = trees[0]
-    tables = tskit.TableCollection(1)
+    tables = tskit.TableCollection(span)
     nodes = tables.nodes
     nodes.metadata_schema = tskit.MetadataSchema(
         {


### PR DESCRIPTION
And make min_edge_length argument keyword-only (this is a breaking change, so although it seems sensible to me, I have put it as a separate commit)

I chose `span` rather than `sequence_length` as the parameter name to match the argument used in e.g. `Tree.generate_balanced`, but I'm happy with either.

Fixes #40 